### PR TITLE
Edge/qa2024001

### DIFF
--- a/archive/witch_spells/dataset/db.json
+++ b/archive/witch_spells/dataset/db.json
@@ -206,6 +206,11 @@
             "command": "lsof @@file"
         },
         {
+            "name": "file.str",
+            "description": "Strings alias",
+            "command": "strings @@file"
+        },
+        {
             "name": "file.clean.meta",
             "description": "Removes all metadata from an image to protect privacy",
             "command": "exiftool -all= @@image"
@@ -386,8 +391,8 @@
             "command": "search.ipscore --ip ip_address"
         },
         {
-            "name": "search.social",
-            "description": "Social media profile search",
+            "name": "search.meta",
+            "description": "Social media profile search in over 1000 platforms",
             "command": "search.social --keyword nickname"
         },
         {

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: witchcraft-cybersecurity
-version: "0.20.20"
+version: "0.20.21"
 summary: Your OPSEC companion!
 icon: "witch_docs/media_kit/logo-1.png"
 grade: stable

--- a/witch_craft/Cargo.toml
+++ b/witch_craft/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "witch_craft"
-version = "0.20.20"
+version = "0.20.21"
 edition = "2021"
 readme = "README.md"
 homepage = "https://cosmic-zip.github.io/wiki/wiki.html"

--- a/witch_craft/src/core/consts.rs
+++ b/witch_craft/src/core/consts.rs
@@ -3,7 +3,7 @@ pub const SPLIT_II: &str = "--";
 pub const SPLIT_I: &str = "-";
 pub const DBPATH: &str = "dataset/db.json";
 pub const WITCH_SPELLS_ROOT_DIR: &str = "/var/archive/witch_spells/";
-pub const VERSION: &str = "Version: 0.20.20 by cosmic-zip";
+pub const VERSION: &str = "Version: 0.20.21 by cosmic-zip";
 
 pub const MAGIC_DOCS: &[(&str, &str)] = &[
     ("account", "Generic arguments for account info or token"),

--- a/witch_craft/src/core/core.rs
+++ b/witch_craft/src/core/core.rs
@@ -456,7 +456,7 @@ pub fn lazy_exec(command_line: String) -> i32 {
                 }
             } else {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                raise(&format!("blackcat_av :: {}", stderr.to_string()), "fail");
+                raise(&format!("{}", stderr.to_string()), "");
             }
             println!(" ");
             output.status.code().unwrap_or(128)

--- a/witch_craft/src/modules/binds/binds.rs
+++ b/witch_craft/src/modules/binds/binds.rs
@@ -64,12 +64,7 @@ pub fn flawless_entry_point(argsv: &[String]) -> i32 {
     let data = data();
     for set in data {
         if set.name == mname {
-            let out = flawless_exec(set.clone(), argsv);
-            if out != 0 {
-                raise("Shell falied to execute at flawless_exec()", "fail");
-                raise(&set.meta, "fail");
-                return out;
-            }
+            return flawless_exec(set.clone(), argsv);
         }
     }
 

--- a/witch_craft/src/modules/network/ddos.rs
+++ b/witch_craft/src/modules/network/ddos.rs
@@ -8,7 +8,13 @@ pub fn seach_number_value(key: &str, argsv: &[String]) -> i32 {
 
 pub fn dos_simple_get_span(argsv: &[String]) -> i32 {
     let mut req = Request::new();
-    req.url = search_value("domain", argsv);
+
+    let mut vurl = search_value("domain", argsv);
+    if !vurl.contains("http://") && !vurl.contains("https://") {
+        vurl = format!("https://{}", vurl);
+    }
+
+    req.url = vurl;
     req.method = "GET".to_string();
 
     let times = seach_number_value("times", argsv);
@@ -24,7 +30,14 @@ pub fn dos_long_auth_span(argsv: &[String]) -> i32 {
     // let size = seach_number_value("size", argsv);
     let seed = "3l34_=3k4vç~4vu,,20-v";
     let mut req = Request::new();
-    req.url = search_value("domain", argsv);
+
+    let mut vurl = search_value("domain", argsv);
+    if !vurl.contains("http://") && !vurl.contains("https://") {
+        vurl = format!("https://{}", vurl);
+    }
+
+    req.url = vurl;
+
     req.method = "GET".to_string();
     req.body = Some(HashMap::from([
         ("user", seed),

--- a/witch_craft/src/modules/osint/lookup.rs
+++ b/witch_craft/src/modules/osint/lookup.rs
@@ -1,7 +1,7 @@
 use crate::core::core::*;
 
 pub fn search_ans(argsv: &[String]) -> i32 {
-    let mut ans_number = search_value("asn", argsv);
+    let mut ans_number = search_value("ip", argsv);
     ans_number = ip_to_number(&ans_number);
 
     if ans_number.len() <= 10 {


### PR DESCRIPTION
Revision 0.20.21

Date: Wed Nov 6 10:38:08 AM -03 2024

-   Update revision to 0.20.21
-   Fixed unnecessary error message when a command returns an error code with no stderr
-   fixed DOS attack incomplete url
-   Fixed chromium deps
-   Fixed renamed incorrectly named function from dos.simple to dos.spam
-   Updated documentation